### PR TITLE
fix: json 전송시 명칭 통일

### DIFF
--- a/app/structure/lib/dataSource/remote_data_source.dart
+++ b/app/structure/lib/dataSource/remote_data_source.dart
@@ -9,10 +9,48 @@ import 'package:http/http.dart' as http;
 import 'package:xml2json/xml2json.dart';
 
 class RemoteDataSource {
-  // static String baseUrl = 'http://3.39.51.41';
-  static String baseUrl = 'http://54.180.132.204:8080';
+  // static String baseUrl = 'http://3.39.51.41'; // 원본 서버
+  static String baseUrl = 'http://54.180.132.204:8080'; // 테스트 서버
 
-  // 육류 정보 전송 (POST)
+  /* 사용자 관련 API */
+  /// 유저 회원가입 (POST)
+  static Future<dynamic> signUp(String jsonData) async {
+    dynamic response = await _postApi('user/register', jsonData);
+    return response;
+  }
+
+  /// 유저 업데이트 (POST)
+  static Future<dynamic> updateUser(String jsonData) async {
+    dynamic response = await _postApi('user/update', jsonData);
+    return response;
+  }
+
+  /// 유저 비밀번호 변경 (POST)
+  static Future<dynamic> changeUserPw(String jsonData) async {
+    dynamic response = await _postApi('user/update', jsonData);
+    return response;
+  }
+
+  /// 유저 비밀번호 검사 (POST)
+  static Future<dynamic> checkUserPw(String jsonData) async {
+    dynamic response = await _postApi('user/pwd_check', jsonData);
+    return response;
+  }
+
+  /// 유저 로그인 (GET)
+  static Future<dynamic> signIn(String userId) async {
+    dynamic response = await _getApi('user/login?userId=$userId');
+    return response;
+  }
+
+  /// 유저 중복검사 (GET)
+  static Future<dynamic> dupliCheck(String userId) async {
+    dynamic response = await _getApi('user/duplicate_check?userId=$userId');
+    return response;
+  }
+
+  /* 육류 관련 API */
+  /// 육류 정보 전송 (POST)
   static Future<dynamic> sendMeatData(String? dest, String jsonData) async {
     String endPoint = 'meat/add';
     if (dest != null) {
@@ -22,50 +60,26 @@ class RemoteDataSource {
     return response;
   }
 
-  // 유저 회원가입 (POST)
-  static Future<dynamic> signUp(String jsonData) async {
-    dynamic response = await _postApi('user/register', jsonData);
-    return response;
-  }
-
-  // 유저 업데이트 (POST)
-  static Future<dynamic> updateUser(String jsonData) async {
-    dynamic response = await _postApi('user/update', jsonData);
-    return response;
-  }
-
-  // 유저 비밀번호 변경 (POST)
-  static Future<dynamic> changeUserPw(String jsonData) async {
-    dynamic response = await _postApi('user/update', jsonData);
-    return response;
-  }
-
-  // 유저 비밀번호 검사 (POST)
-  static Future<dynamic> checkUserPw(String jsonData) async {
-    dynamic response = await _postApi('user/pwd_check', jsonData);
-    return response;
-  }
-
-  // 관리번호 육류 정보 조회 (GET)
+  /// 관리번호 육류 정보 조회 (GET)
   static Future<dynamic> getMeatData(String id) async {
     dynamic response = await _getApi('meat/get?id=$id');
     return response;
   }
 
-  // 딥에이징 데이터 삭제 (GET)
+  /// 딥에이징 데이터 삭제 (GET)
   static Future<dynamic> deleteDeepAging(String id, int seqno) async {
     dynamic response =
         await _getApi('meat/delete/deep_aging?id=$id&seqno=$seqno');
     return response;
   }
 
-  // 승인된 관리번호 검색
+  /// 승인된 관리번호 검색
   static Future<dynamic> getConfirmedMeatData() async {
     dynamic response = await _getApi('meat/status?statusType=2');
     return response;
   }
 
-  // 유저가 등록한 관리번호 조회 (GET)
+  /// 유저가 등록한 관리번호 조회 (GET)
   static Future<dynamic> getUserMeatData(String? dest) async {
     String endPoint = 'meat/user';
     if (dest != null) {
@@ -75,31 +89,19 @@ class RemoteDataSource {
     return response;
   }
 
-  // 육류 데이터 승인 (GET)
+  /// 육류 데이터 승인 (GET)
   static Future<dynamic> confirmMeatData(String meatId) async {
     dynamic response = await _getApi('meat/confirm?id=$meatId');
     return response;
   }
 
-  // 유저 로그인 (GET)
-  static Future<dynamic> signIn(String userId) async {
-    dynamic response = await _getApi('user/login?id=$userId');
-    return response;
-  }
-
-  // 유저 중복검사 (GET)
-  static Future<dynamic> dupliCheck(String userId) async {
-    dynamic response = await _getApi('user/duplicate_check?id=$userId');
-    return response;
-  }
-
-  // 종, 부위 조회 (GET)
+  /// 종, 부위 조회 (GET)
   static Future<dynamic> getMeatSpecies() async {
     dynamic response = await _getApi('data');
     return response;
   }
 
-  // API POST
+  /// API POST
   static Future<dynamic> _postApi(String endPoint, String jsonData) async {
     String apiUrl = '$baseUrl/$endPoint';
     Map<String, String> headers = {'Content-Type': 'application/json'};
@@ -122,7 +124,7 @@ class RemoteDataSource {
     }
   }
 
-  // API GET
+  /// API GET
   static Future<dynamic> _getApi(String endPoint) async {
     String apiUrl = '$baseUrl/$endPoint';
     try {
@@ -141,7 +143,7 @@ class RemoteDataSource {
     }
   }
 
-  // 육류 이력관리 정보 (GET)
+  /// 육류 이력관리 정보 (GET)
   static Future<dynamic> getMeatTraceData(String url) async {
     try {
       final response = await http.get(Uri.parse(url));

--- a/app/structure/lib/viewModel/my_page/change_password_view_model.dart
+++ b/app/structure/lib/viewModel/my_page/change_password_view_model.dart
@@ -130,7 +130,7 @@ class ChangePasswordViewModel with ChangeNotifier {
   // 유저 비밀번호 확인
   String _userInfoToJson() {
     return jsonEncode({
-      "id": userModel.userId,
+      "userId": userModel.userId,
       "password": originPW.text,
     });
   }


### PR DESCRIPTION
API 종류별로 보기 편하게 재배치
유저 아이디 json 명칭 userId로 통일
육류 id도 meatId로 변경할지 논의 필요